### PR TITLE
Added `types` package

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,0 +1,10 @@
+export type Resource = {
+	id: string;
+	type: "resource";
+	title: string;
+	description: string;
+	url: string;
+	createdBy: string;
+	createdAt: string;
+	updatedAt: string | null;
+};

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@swe-tube/types",
+	"version": "0.1.0",
+	"description": "SWE-Tube type definitions.",
+	"main": "index.ts",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [
+		"SWE Tube",
+		"types"
+	],
+	"author": "Matthew Gibbons <matthew.gibbons@multiverse.io>",
+	"devDependencies": {
+		"typescript": "^4.9.5"
+	}
+}

--- a/packages/types/pnpm-lock.yaml
+++ b/packages/types/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: 5.4
+
+specifiers:
+  typescript: ^4.9.5
+
+devDependencies:
+  typescript: 4.9.5
+
+packages:
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true


### PR DESCRIPTION
Added a stub for a project-wide types package. We're not using TypeScript in the implementation of the project, but having types available (think: `@types/node`) is really helpful in crafting sensible JSDoc type comments.