### PR TITLE
Add support for Express server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,15 +1,18 @@
 {
-  "scripts": {
-    "dev": "netlify functions:serve",
-    "test": "jest src/",
-    "test:e2e": "jest test/"
-  },
-  "devDependencies": {
-    "@netlify/functions": "^1.4.0",
-    "@types/express": "^4.17.17",
-    "cors": "^2.8.5",
-    "express": "^4.18.2",
-    "serverless-http": "^3.1.1",
-    "supertest": "^6.3.3"
-  }
+	"name": "api",
+	"description": "SWE-Tube API service.",
+	"scripts": {
+		"dev": "node src/index.js",
+		"dev:netlify": "netlify functions:serve",
+		"test": "jest src/",
+		"test:e2e": "jest test/"
+	},
+	"devDependencies": {
+		"@netlify/functions": "^1.4.0",
+		"@types/express": "^4.17.17",
+		"cors": "^2.8.5",
+		"express": "^4.18.2",
+		"serverless-http": "^3.1.1",
+		"supertest": "^6.3.3"
+	}
 }

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,0 +1,12 @@
+const cors = require("cors");
+const express = require("express");
+const resources = require("./functions/resources/router.js");
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use("/resources", resources);
+
+module.exports = app;

--- a/apps/api/src/functions/resources/app.js
+++ b/apps/api/src/functions/resources/app.js
@@ -8,9 +8,9 @@ app.use(cors());
 app.use(express.json());
 
 if (process.env["NETLIFY_DEV"]) {
-  app.use("/.netlify/functions/resources", router);
+	app.use("/.netlify/functions/resources", router);
 } else {
-  app.use("/resources");
+	app.use("/resources", router);
 }
 
 module.exports = app;

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -1,0 +1,19 @@
+const app = require("./app.js");
+
+const PORT = process.env["PORT"] ?? 3000;
+
+if (require.main === module) {
+	app
+		.listen(PORT, () => {
+			console.log(`Listening on port ${PORT}`);
+		})
+		.on("error", (err) => {
+			if (/EADDRINUSE/.test(err.message)) {
+				console.error(
+					`Error: port ${PORT} is already in use - please close the other server and try again`
+				);
+			} else {
+				console.error(err.message);
+			}
+		});
+}


### PR DESCRIPTION
I have added two new files in the root of `src` that implement a standard Express server, utilising the router from the `resources` function. This serves a couple of purposes:

1. The Express server implementation is the default for development. This will be more familiar to apprentices. However, I have added an alternative dev script to locally serve the functions via the Netlify CLI.
2. The Express server implementation will compose its routes from individual functions. This demonstrates quite clearly the purpose and advantage of decomposition and separation of concerns. 

One consideration is that we rename the `functions` folder to `services` (or similar) to emphasise that the `api` is concerned with services, whether they are served locally or deployed remotely. The fact the we can leverage Netlify functions to achieve this is an implementation detail.